### PR TITLE
Add prototype for producing an Observable with a marble diagram

### DIFF
--- a/src/test/kotlin/com/rubylichtenstein/rxtest/rxmarble/Marble.kt
+++ b/src/test/kotlin/com/rubylichtenstein/rxtest/rxmarble/Marble.kt
@@ -1,0 +1,100 @@
+package com.rubylichtenstein.rxtest.rxmarble
+
+
+import io.reactivex.Observable
+import io.reactivex.Scheduler
+import io.reactivex.schedulers.TestScheduler
+import java.lang.RuntimeException
+import java.util.concurrent.TimeUnit
+
+
+const val TICK = 15L
+
+fun <T> rxmarble(marbles: String, scheduler: Scheduler, tickMs: Long = TICK, operation: (Int) -> T): Observable<T> {
+    val rxm = RxMarble(marbles, true, tickMs, 100L, scheduler)
+    rxm.checkMarbles(marbles)
+    val mapping: List<T> = try {
+        val numbers = 1..(rxm.parseNumbers(marbles).max() ?: 1)
+        numbers.map(operation)
+    } catch (e: Throwable) {
+        throw IllegalArgumentException("Marble [$marbles] : mapping function throwed $e")
+    }
+    return rxm.create().map { mapping[it - 1] }
+}
+
+fun <T> rxmarble(marbles: String, scheduler: Scheduler, tickMs: Long = TICK, mapping: List<T>): Observable<T> {
+    val rxm = RxMarble(marbles, true, tickMs, 100L, scheduler)
+    rxm.checkMarbles(marbles)
+    val invalidNumbers = rxm.parseNumbers(marbles).filter { it !in 1..mapping.size }
+    require(invalidNumbers.isEmpty()) { "Marble [$marbles]: indexes $invalidNumbers not found in list $mapping" }
+    return rxm.create().map { mapping[it - 1] }
+}
+
+
+fun TestScheduler.advanceByFrame(nb: Int, tickMs: Long = TICK): TestScheduler {
+    this.advanceTimeBy(tickMs * nb, TimeUnit.MILLISECONDS)
+    return this
+}
+
+
+class RxMarble(val marbles: String, val hot: Boolean, val tickMs: Long, val max: Long, val scheduler: Scheduler) {
+
+
+    internal fun checkMarbles(marbles: String, hot: Boolean = false) {
+        val invalidChars = marbles.filterNot { it in NUMBERS || it in OTHERS }
+        require(invalidChars.isEmpty()) {
+            "Marble: [$marbles] contains invalid characters [$invalidChars]"
+        }
+        require(marbles.filter { it == '^' }.count() <= 1) {
+            "Marble [$marbles]  contains multiple subscriptions"
+        }
+        require(marbles.filter { it == '#' || it == '|' }.count() <= 1) {
+            "Marble [$marbles] contains multiple terminal events"
+        }
+        require(hot || !marbles.contains('^')) {
+            "Marble [$marbles] is cold but contains a subscription point"
+        }
+    }
+
+    internal fun parseNumbers(marbles: String): List<Int> {
+        return marbles.split(*OTHERS).mapNotNull { it.toIntOrNull() }.distinct().sorted()
+    }
+
+    internal fun firstFrame(): Long {
+        val first = if (hot) marbles.indexOfFirst { it == '^' } else -1
+        return if (first == -1) 0L else first.toLong()
+    }
+
+    internal fun lastFrame(): Long {
+        val end = marbles.indexOfFirst { it == '#' || it == '|' }
+        return if (end == -1) max else end.toLong()
+    }
+
+    internal fun completion(): Observable<Int> {
+        val end = marbles.firstOrNull { it == '#' || it == '|' }
+        return when (end) {
+            null -> Observable.never()
+            '#' -> Observable.error(MarbleError)
+            '|' -> Observable.empty()
+            else -> TODO("invalid completion ${completion()}")
+        }
+    }
+
+    fun create(): Observable<Int> {
+        return Observable.merge(Observable.interval(tickMs, TimeUnit.MILLISECONDS, scheduler)
+                .take(lastFrame())
+                .skip(firstFrame())
+                .map { l -> marbles.getOrNull(l.toInt()) ?: "-" }
+                .filter { it in NUMBERS }
+                .map { "$it".toInt() },
+                completion())
+    }
+
+    companion object {
+        private val NUMBERS = '0'..'9'
+        private val OTHERS = charArrayOf('|', '^', '#', '-', '(', ')')
+    }
+
+    object MarbleError : RuntimeException("Marble emitted an error")
+}
+

--- a/src/test/kotlin/com/rubylichtenstein/rxtest/rxmarble/MarbleTest.kt
+++ b/src/test/kotlin/com/rubylichtenstein/rxtest/rxmarble/MarbleTest.kt
@@ -1,0 +1,189 @@
+package com.rubylichtenstein.rxtest.rxmarble
+
+import com.rubylichtenstein.rxtest.assertions.shouldEmit
+import com.rubylichtenstein.rxtest.assertions.shouldHave
+import com.rubylichtenstein.rxtest.assertions.shouldNeverEmit
+import com.rubylichtenstein.rxtest.extentions.test
+import com.rubylichtenstein.rxtest.matchers.*
+import io.reactivex.Observable
+import io.reactivex.schedulers.TestScheduler
+import junit.framework.AssertionFailedError
+import org.jetbrains.spek.api.Spek
+import org.jetbrains.spek.api.dsl.describe
+import org.jetbrains.spek.api.dsl.it
+import org.jetbrains.spek.api.dsl.on
+import java.util.concurrent.TimeUnit
+import kotlin.test.assertEquals
+import kotlin.test.assertTrue
+
+
+class MarbleTest : Spek({
+    val scheduler = TestScheduler()
+    val tick = 15L
+    fun advanceTime(intervals: Int) {
+        scheduler.advanceTimeBy(intervals * tick, TimeUnit.MILLISECONDS)
+    }
+
+    describe("marble") {
+
+        it("use a marble of indexes and a mapping list of any type") {
+            rxmarble(
+                    "--1---3-|", scheduler, tick,
+                    listOf(2, 4, 9)
+            ).test {
+                advanceTime(10)
+                it shouldEmit values(2, 9)
+            }
+
+            rxmarble(
+                    "--1-2-3-|", scheduler, tick,
+                    listOf("hello", "world", "!")
+            ).test {
+                advanceTime(10)
+                it shouldEmit values("hello", "world", "!")
+            }
+
+
+            rxmarble("--1-2--3--|", scheduler, tick,
+                    listOf(true, false, true)
+            ).test {
+                advanceTime(10)
+                it shouldEmit values(true, false, true)
+                it shouldHave complete()
+
+            }
+        }
+
+        it("can does the mapping with a lambda") {
+            rxmarble(
+                    "--1-6-8--", scheduler, tick,
+                    { index : Int -> "Got: $index" }
+            ).test {
+                advanceTime(10)
+                it shouldEmit values("Got: 1", "Got: 6", "Got: 8")
+                it shouldHave notComplete()
+            }
+
+        }
+
+
+        on("---1--2--4---|") {
+            val observable: Observable<Int> = rxmarble(
+                    "---1--2--4---|", scheduler, tick,
+                    listOf(2, 4, 9, 16) // values emitted for the indexes 1, 2 and 4
+            )
+            observable.test {
+                it("starts empty") {
+                    it shouldEmit values()
+                    it shouldHave notComplete()
+                }
+
+                it("should then emits 2") {
+                    advanceTime(4)
+                    it shouldEmit values(2)
+                    it shouldHave notComplete()
+                    it shouldHave noErrors()
+                }
+
+                it("should then emit 4, 16, |") {
+                    advanceTime(10)
+                    it shouldEmit values(2, 4, 16)
+                    it shouldHave noErrors()
+                    it shouldHave complete()
+                }
+
+
+
+            }
+
+
+        }
+
+
+
+
+        it("emits errors for ---#") {
+            rxmarble(
+                    "---#", scheduler, tick, listOf(42)
+            ).test {
+                advanceTime(10)
+                it shouldHave failure(RxMarble.MarbleError::class.java)
+            }
+        }
+    }
+
+
+
+    describe("invalid marbles") {
+        val scheduler = TestScheduler()
+        val ints = (1..12).map { it * it }
+
+        it("has indices starting at 1, not 0") {
+            val message = illegalArgument {
+                rxmarble("--0--", scheduler, mapping = ints)
+            }
+            assertTrue { message.contains("[0]"); message.contains("not found") }
+
+        }
+
+        it("rejects invalid indices") {
+            val message = illegalArgument {
+                rxmarble("--1--13", scheduler, mapping = ints)
+            }
+            assertTrue { message.contains("[13]"); message.contains("not found") }
+        }
+
+        it("should not accept letters") {
+            // contrary to the javascript marble, we don't accept letters
+            val message = illegalArgument {
+                rxmarble("--1-2-a---", scheduler, mapping = ints)
+            }
+            assertTrue { message.contains("invalid characters") }
+        }
+
+        it("should not have multiple subscriptions") {
+            val message = illegalArgument {
+                rxmarble("--^-^-1---", scheduler, mapping = ints)
+            }
+            assertTrue { message.contains("multiple subscriptions") }
+        }
+
+        it("should not have multiple terminal events") {
+            val invalids = listOf("-#-|", "--||", "--#-#")
+            for (marble in invalids) {
+                val message = illegalArgument {
+                    rxmarble(marble, scheduler, mapping = ints)
+                }
+                assertTrue { message.contains("multiple terminal events") }
+            }
+
+        }
+
+        it("tests that the lambda function would not crash") {
+            illegalArgument {
+                val list = listOf(1, 2)
+                rxmarble(
+                        "--1--2-4---", scheduler, tick,
+                        { list[it] }
+                )
+            }
+        }
+
+    }
+})
+
+
+fun illegalArgument(function: () -> Unit): String {
+    val e = try {
+        function.invoke()
+        null
+    } catch (e: Throwable) {
+        e
+    }
+    when (e) {
+        null -> throw AssertionFailedError("Was expected to fail with IllegalArgumentException, got accepted instead")
+        is IllegalArgumentException -> return e.message ?: ""
+        else -> throw AssertionFailedError("Was expected to fail with IllegalArgumentException, throwed instead $e")
+    }
+
+}


### PR DESCRIPTION
```kt
val o: Observable<String> = rxmarble(
     "--1---3-|", scheduler, tick,
     listOf("2", "4", "9")
)
```

The marble diagram describes when things are emitted, the list is a mapping that describes what is emitted for a given index (starting at 1). If you use a mapping of type `List<T>` you get an `Observable<T>`. Alternatively you can pass a lambda. 

In this case, the observable

wait 30 ms, 
produce "2" (first element of the list)
wait 45ms, 
produce "9" (third element of the list), 
wait 15ms,
complete

Inspired by https://github.com/ReactiveX/rxjs/blob/master/doc/writing-marble-tests.md

API: instable
Bugs: a lot
Missing features: a lot